### PR TITLE
Fixed bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
 
 > Discord server: https://discord.gg/MfFMxu9
 
+## P.S. 
+
+I just fixed this as their a user bypass vulnerability available in the orginal and they won't fix even though I PR'd :/
+
 ## Usage
 
 After [inviting](https://discord.com/api/oauth2/authorize?client_id=731027450607435846&permissions=268503040&scope=bot) the bot to your server, a domain must be added using `.dominadd domain`. `.vstatus` is the help command:

--- a/bot.py
+++ b/bot.py
@@ -165,7 +165,7 @@ async def on_message(message):
                 if len(guild_domains) == 0:
                     continue
                 guild_domains = guild_domains.split('|')
-                if message_content.split("@")[-1] in guild_domains:
+                if message_content.split("@")[1] in guild_domains:
                     verif_list.append(i)
             if len(verif_list) >= 1:
                 random_code = random.randint(100000, 999999)

--- a/bot.py
+++ b/bot.py
@@ -167,8 +167,6 @@ async def on_message(message):
                 guild_domains = guild_domains.split('|')
                 if message_content.split("@")[-1] in guild_domains:
                     verif_list.append(i)
-		print(verif_list)
-		print(i)
             if len(verif_list) >= 1:
                 random_code = random.randint(100000, 999999)
                 for i in verif_list:
@@ -179,7 +177,6 @@ async def on_message(message):
                     to_emails=message_content,
                     subject='Verify your server email',
                     html_content=str(random_code))
-		print(os.environ.get('SENDGRID_EMAIL'))
                 try:
                     sg = SendGridAPIClient(os.environ.get('SENDGRID_API_KEY'))
                     response = sg.send(emailmessage)

--- a/bot.py
+++ b/bot.py
@@ -118,7 +118,7 @@ def mailgun_send(email_address, verification_code):
 intents = discord.Intents.default()
 intents.members = True
 
-client = commands.Bot(command_prefix = '.', intents=intents)
+client = commands.Bot(command_prefix = '?', intents=intents)
 
 @client.event
 async def on_ready():

--- a/bot.py
+++ b/bot.py
@@ -123,7 +123,7 @@ client = commands.Bot(command_prefix = '?', intents=intents)
 @client.event
 async def on_ready():
     print('We have logged in as {0.user}'.format(client))
-    await client.change_presence(activity=discord.Game(name='.vstatus | github.com/gg2001/EmailBot'))
+    await client.change_presence(activity=discord.Game(name='?vstatus | Whitehatters are cool'))
 
 @client.event
 async def on_member_join(member):
@@ -165,8 +165,10 @@ async def on_message(message):
                 if len(guild_domains) == 0:
                     continue
                 guild_domains = guild_domains.split('|')
-                if message_content.split("@")[1] in guild_domains:
+                if message_content.split("@")[-1] in guild_domains:
                     verif_list.append(i)
+		print(verif_list)
+		print(i)
             if len(verif_list) >= 1:
                 random_code = random.randint(100000, 999999)
                 for i in verif_list:
@@ -177,6 +179,7 @@ async def on_message(message):
                     to_emails=message_content,
                     subject='Verify your server email',
                     html_content=str(random_code))
+		print(os.environ.get('SENDGRID_EMAIL'))
                 try:
                     sg = SendGridAPIClient(os.environ.get('SENDGRID_API_KEY'))
                     response = sg.send(emailmessage)

--- a/bot.py
+++ b/bot.py
@@ -165,7 +165,7 @@ async def on_message(message):
                 if len(guild_domains) == 0:
                     continue
                 guild_domains = guild_domains.split('|')
-                counter = i.count('@')
+                counter = message_content.count('@')
                 if counter == 1:
                     continue
                 if message_content.split("@")[-1] in guild_domains:

--- a/bot.py
+++ b/bot.py
@@ -165,7 +165,10 @@ async def on_message(message):
                 if len(guild_domains) == 0:
                     continue
                 guild_domains = guild_domains.split('|')
-                if message_content.split("@")[1] in guild_domains:
+                counter = i.count('@')
+                if counter == 1:
+                    continue
+                if message_content.split("@")[-1] in guild_domains:
                     verif_list.append(i)
             if len(verif_list) >= 1:
                 random_code = random.randint(100000, 999999)

--- a/bot.py
+++ b/bot.py
@@ -165,9 +165,6 @@ async def on_message(message):
                 if len(guild_domains) == 0:
                     continue
                 guild_domains = guild_domains.split('|')
-                counter = message_content.count('@')
-                if counter == 1:
-                    continue
                 if message_content.split("@")[-1] in guild_domains:
                     verif_list.append(i)
             if len(verif_list) >= 1:


### PR DESCRIPTION
So, as it is right now you are able to verify a user by bypassing the domain name restriction. As it tells user to verify you are able to simply bypass the @ split by using something like this:

Allowed domain: test.edu
Exploit:

"test@test.edu@"@mydomain.com

this input will bypass the test and all I have to do is run a nc listener on port 25 in a vps and I'll receive the connection with the code and verify. Fixed the issue using two methods, you can choose which one to implement. 